### PR TITLE
beamerinnertheme: Fix logo size

### DIFF
--- a/2015/beamerinnerthemeguadec.sty
+++ b/2015/beamerinnerthemeguadec.sty
@@ -39,7 +39,7 @@
 % Title page
 \defbeamertemplate*{title page}{guadec}[1][] {
   \centering
-  \includegraphics[height=0.21\paperheight]{guadec-logo}
+  \includegraphics[width=0.672\paperheight,height=0.21\paperheight,keepaspectratio]{guadec-logo}
   \vskip6mm%
   \hfill
   \begin{beamercolorbox}[wd=0.66\paperwidth, center, sep=8pt, #1]{title page header}


### PR DESCRIPTION
The title page's GUADEC logo size was loosely defined, this make its
definition more robust.

Fixes #5
